### PR TITLE
Enable treat warnings as errors

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -46,6 +46,9 @@ dotnet_naming_rule.constants_should_be_pascal_case.style = constant_style
 # Apply our rule to constants.
 dotnet_naming_style.constant_style.capitalization = pascal_case
 
+# Disable CA1014
+dotnet_diagnostic.CA1014.severity = none
+
 [*.{received,verified}.*]
 generated_code = true
 

--- a/Devantler.KeyManager.Core/Devantler.KeyManager.Core.csproj
+++ b/Devantler.KeyManager.Core/Devantler.KeyManager.Core.csproj
@@ -6,6 +6,7 @@
     <Nullable>enable</Nullable>
     <AnalysisLevel>preview-all</AnalysisLevel>
     <EnforceCodeStyleInBuild>true</EnforceCodeStyleInBuild>
+    <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
     <CodeAnalysisTreatWarningsAsErrors>false</CodeAnalysisTreatWarningsAsErrors>
   </PropertyGroup>

--- a/Devantler.KeyManager.Core/Models/SOPSConfig.cs
+++ b/Devantler.KeyManager.Core/Models/SOPSConfig.cs
@@ -13,5 +13,3 @@ public class SOPSConfig
   /// </summary>
   public required Collection<SOPSConfigCreationRule> CreationRules { get; set; } = [];
 }
-
-

--- a/Devantler.KeyManager.Core/Models/SOPSConfig.cs
+++ b/Devantler.KeyManager.Core/Models/SOPSConfig.cs
@@ -1,3 +1,4 @@
+#pragma warning disable CA2227
 using System.Collections.ObjectModel;
 
 namespace Devantler.KeyManager.Core.Models;
@@ -10,9 +11,7 @@ public class SOPSConfig
   /// <summary>
   /// A list of creation rules.
   /// </summary>
-#pragma warning disable CA2227
   public required Collection<SOPSConfigCreationRule> CreationRules { get; set; } = [];
-#pragma warning restore CA2227
 }
 
 

--- a/Devantler.KeyManager.Local.Age.Tests/Devantler.KeyManager.Local.Age.Tests.csproj
+++ b/Devantler.KeyManager.Local.Age.Tests/Devantler.KeyManager.Local.Age.Tests.csproj
@@ -6,6 +6,7 @@
     <Nullable>enable</Nullable>
     <AnalysisLevel>preview-all</AnalysisLevel>
     <EnforceCodeStyleInBuild>true</EnforceCodeStyleInBuild>
+    <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
     <CodeAnalysisTreatWarningsAsErrors>false</CodeAnalysisTreatWarningsAsErrors>
 

--- a/Devantler.KeyManager.Local.Age/Devantler.KeyManager.Local.Age.csproj
+++ b/Devantler.KeyManager.Local.Age/Devantler.KeyManager.Local.Age.csproj
@@ -6,6 +6,7 @@
     <Nullable>enable</Nullable>
     <AnalysisLevel>preview-all</AnalysisLevel>
     <EnforceCodeStyleInBuild>true</EnforceCodeStyleInBuild>
+    <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
     <CodeAnalysisTreatWarningsAsErrors>false</CodeAnalysisTreatWarningsAsErrors>
   </PropertyGroup>


### PR DESCRIPTION
This pull request enables the "TreatWarningsAsErrors" setting in the project file, which treats warnings as errors during the build process. Additionally, it disables the CA1014 diagnostic rule.