### PR TITLE
Throw exception when trying to write to an existing file

### DIFF
--- a/Devantler.KeyManager.Local.Age/LocalAgeKeyManager.cs
+++ b/Devantler.KeyManager.Local.Age/LocalAgeKeyManager.cs
@@ -283,7 +283,7 @@ public class LocalAgeKeyManager() : ILocalKeyManager<AgeKey>
   public async Task CreateSOPSConfigAsync(string configPath, SOPSConfig config, bool overwrite = false, CancellationToken cancellationToken = default)
   {
     if (!overwrite && File.Exists(configPath))
-      return;
+      throw new InvalidOperationException("The file already exists and overwrite is set to false.");
 
     // Create the directory if it does not exist.
     string? directory = Path.GetDirectoryName(configPath);


### PR DESCRIPTION
This pull request adds a check to throw an exception if attempting to write to a file that already exists, without explicitly enforcing it. This prevents accidental overwriting of existing files.