### PR TITLE
Add file existence check in ListKeysAsync method

### DIFF
--- a/Devantler.KeyManager.Local.Age/LocalAgeKeyManager.cs
+++ b/Devantler.KeyManager.Local.Age/LocalAgeKeyManager.cs
@@ -246,7 +246,9 @@ public class LocalAgeKeyManager() : ILocalKeyManager<AgeKey>
   /// <inheritdoc/>
   public async Task<IEnumerable<AgeKey>> ListKeysAsync(string keyPath, CancellationToken cancellationToken = default)
   {
-    // Get the contents of the file.
+    if (!File.Exists(keyPath))
+      return [];
+
     string fileContents = await File.ReadAllTextAsync(keyPath, cancellationToken).ConfigureAwait(false);
 
     // Find the line number with the public key


### PR DESCRIPTION
Implement a check for file existence in the ListKeysAsync method to prevent errors when attempting to read a non-existent file.